### PR TITLE
Various fixes

### DIFF
--- a/pooler.lisp
+++ b/pooler.lisp
@@ -54,7 +54,7 @@
   (capacity 40 :type fixnum)
   (threshold 2 :type fixnum)
   (timeout 300 :type fixnum)
-  (last-access 0 :type fixnum)
+  (last-access 0 :type integer)
   (current-size 0 :type fixnum)
   (total-uses 0 :type fixnum)
   (total-created 0 :type fixnum)

--- a/pooler.lisp
+++ b/pooler.lisp
@@ -45,7 +45,7 @@
 ;;; last-acccess - last access timestamp
 ;;;
 
-(defstruct (pool (:constructor make-pool (&key name capacity threshold item-maker item-destroyer)))
+(defstruct (pool (:constructor make-pool (&key name capacity threshold item-maker item-destroyer timeout)))
   (name "Default Pool" :type simple-string :read-only t)
   (queue (make-queue))
   (lock (make-pool-lock) :read-only t)


### PR DESCRIPTION
This merge request contains a number of fixes:
- The destroy function needs to be called on objects that are expired because of a timeout.
- It should be possible to specify the timeout as a parameter to `make-pool`
- Change the type of `last-access` to `integer` since a `fixnum` is not large enough to hold a universal timestamp on ABCL
